### PR TITLE
Fix NPE

### DIFF
--- a/src/main/java/codechicken/lib/world/WorldExtension.java
+++ b/src/main/java/codechicken/lib/world/WorldExtension.java
@@ -49,7 +49,7 @@ public abstract class WorldExtension
     
     protected final void unloadChunk(Chunk chunk)
     {
-        chunkMap.get(chunk).unload();
+        if (chunkMap.get(chunk) != null) chunkMap.get(chunk).unload();
     }
     
     protected final void loadChunkData(Chunk chunk, NBTTagCompound tag)


### PR DESCRIPTION
Fix NPE when CodeChickenLib attempts to unload a chunk that is already null:

```
java.lang.NullPointerException: Exception ticking world
	at codechicken.lib.world.WorldExtension.unloadChunk(WorldExtension.java:52)
	at codechicken.lib.world.WorldExtensionManager$WorldExtensionEventHandler.onChunkUnLoad(WorldExtensionManager.java:67)
	at cpw.mods.fml.common.eventhandler.ASMEventHandler_1222_WorldExtensionEventHandler_onChunkUnLoad_Unload.invoke(.dynamic)
	at cpw.mods.fml.common.eventhandler.ASMEventHandler.invoke(ASMEventHandler.java:54)
	at cpw.mods.fml.common.eventhandler.EventBus.post(EventBus.java:140)
	at net.minecraft.world.chunk.Chunk.func_76623_d(Chunk.java:941)
	at net.minecraft.world.gen.ChunkProviderServer.func_73156_b(ChunkProviderServer.java:342)
	at net.minecraft.world.WorldServer.func_72835_b(WorldServer.java:165)
	at net.minecraft.server.MinecraftServer.func_71190_q(MinecraftServer.java:625)
	at net.minecraft.server.dedicated.DedicatedServer.func_71190_q(DedicatedServer.java:334)
	at net.minecraft.server.MinecraftServer.func_71217_p(MinecraftServer.java:547)
	at net.minecraft.server.MinecraftServer.run(MinecraftServer.java:396)
	at net.minecraft.server.MinecraftServer$2.run(MinecraftServer.java:685)
```